### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## 5.1.5 -2019-04-27
+- Refactored HOTWATER Accessory (*)
+- Bugfixes
+- Cleanup code
+
+(*) Added Faucet Accessory with temperature control for HOTWATER (only for devices with temperature adjustment capability). If you have HOTWATER devices with these capability, you need to remove this device from your Cache by setting "active":false into your config.json under the device before updating (IMPORTANT)!
+
+
 ## 5.1.4 - 2019-04-25
 - Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 
 ### Dynamic:
 
-Every thermostat, user (occupancy sensor) or open window detection (window sensor) are affected by the settings in the Tado app. That means, the plugin knows when you turning on/off the open window detection for a thermostat, adding/removing an user or adding/removing a thermostat or just changing the room of a thermostat, the plugin will expose these or remove them dynamically from HomeKit. You dont need to add it manually or even restart homebridge. Just install the plugin, configure the config.json and lean back!
+Every thermostat, faucet for hot water, user (occupancy sensor) or open window detection (window sensor) are affected by the settings in the Tado app. That means, the plugin knows when you turning on/off the open window detection for a thermostat, adding/removing an user or adding/removing a thermostat or just changing the room of a thermostat, the plugin will expose these or remove them dynamically from HomeKit. You dont need to add it manually or even restart homebridge. Just install the plugin, configure the config.json and lean back!
 
 
-This homebridge plugin exposes Tado thermostats, occupancy sensors and weather sensor to Apple's HomeKit. It provides following features:
+This homebridge plugin exposes Tado thermostats, HOTWATER Faucets, occupancy sensors and weather sensor to Apple's HomeKit. It provides following features:
 
 **Thermostats:**
 - Additional modes: Heat, Cool, Auto and Off
@@ -36,8 +36,7 @@ This homebridge plugin exposes Tado thermostats, occupancy sensors and weather s
 
 **Boiler :**
 - Expose Tado Hot Water to Apple HomeKit!
-- Additional modes: Heat, Cool, Auto and Off
-- Auto heat/cool to a certain value (configurable within 3rd party app)
+- Additional modes: Heat, Auto and Off (For HOT WATER devices with temperature adjustment capability)
 
 **Temperature sensors:**
 - If enabled in config.json (externalSensor )this plugin will create temperature sensors for each room.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4-dev.1",
+  "version": "5.1.4-dev.2",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4-dev.3",
+  "version": "5.1.4-dev.4",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4-dev.2",
+  "version": "5.1.4-dev.3",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4",
+  "version": "5.1.4-dev.0",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4-dev.4",
+  "version": "5.1.5",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tado-platform",
-  "version": "5.1.4-dev.0",
+  "version": "5.1.4-dev.1",
   "description": "homebridge-tado-platform",
   "main": "index.js",
   "devDependencies": {},

--- a/src/accessories/boiler.js
+++ b/src/accessories/boiler.js
@@ -164,8 +164,6 @@ class boiler_Accessory {
   
   async setState(state,callback){
   
-    let failed;
-  
     try {
     
       this.logger.info(this.accessory.displayName + ': ' + (state ? 'On' : 'Off'));
@@ -180,27 +178,8 @@ class boiler_Accessory {
     
       this.logger.error(this.accessory.displayName + ': An error occured while setting new state!'); 
       this.debug(err);
-      
-      failed = err;
     
     } finally {
-    
-      if(failed)
-        state = state ? false : true;
-      
-      if(state){
-      
-        this.valveService.getCharacteristic(Characteristic.InUse).updateValue(0);
-        this.valveService.getCharacteristic(Characteristic.Active).updateValue(0); 
-        this.mainService.getCharacteristic(Characteristic.Active).updateValue(0); 
-      
-      } else {
-      
-        this.mainService.getCharacteristic(Characteristic.Active).updateValue(1); 
-        this.valveService.getCharacteristic(Characteristic.Active).updateValue(1); 
-        this.valveService.getCharacteristic(Characteristic.InUse).updateValue(1);
-      
-      }
       
       callback();
     

--- a/src/accessories/boiler.js
+++ b/src/accessories/boiler.js
@@ -2,7 +2,7 @@
 
 var Service, Characteristic;
 
-class thermostat_Accessory {
+class boiler_Accessory {
   constructor (platform, accessory) {
   
     Service = platform.api.hap.Service;
@@ -231,4 +231,4 @@ class thermostat_Accessory {
 
 }
 
-module.exports = thermostat_Accessory;
+module.exports = boiler_Accessory;

--- a/src/accessories/boiler.js
+++ b/src/accessories/boiler.js
@@ -168,7 +168,7 @@ class thermostat_Accessory {
       
       let termination = state ? this.accessory.context.overrideMode : 'manual';
       let onOff = state ? 'on' : 'off';
-      let temp = ( this.accessory.context.canSetTemperature && state ) ? this.valveService.getCharacteristic(Characteristic.HeatingThresholdTemperature).value : null;
+      let temp = ( this.accessory.context.canSetTemperature && state ) ? this.mainService.getCharacteristic(Characteristic.HeatingThresholdTemperature).value : null;
         
       await this.tado.setZoneOverlay(this.accessory.context.homeID,this.accessory.context.zoneID,onOff,temp,termination,this.accessory.context.zoneType);
 

--- a/src/accessories/boiler.js
+++ b/src/accessories/boiler.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const HomeKitTypes = require('../types/types.js');
+
 var Service, Characteristic;
 
 class boiler_Accessory {
@@ -7,6 +9,8 @@ class boiler_Accessory {
   
     Service = platform.api.hap.Service;
     Characteristic = platform.api.hap.Characteristic;
+    
+    HomeKitTypes.registerWith(platform.api.hap);
 
     this.platform = platform;
     this.log = platform.log;

--- a/src/accessories/boiler.js
+++ b/src/accessories/boiler.js
@@ -40,16 +40,16 @@ class thermostat_Accessory {
   
     const self = this;
  
-    if(!this.accessory.getServiceByUUIDAndSubType(Service.Valve, 'Hot Water Valve')){
+    if(!this.accessory.getServiceByUUIDAndSubType(Service.Valve, this.accessory.displayName + ' Valve')){
    
-      this.valveService = new Service.Valve('Hot Water', 'Hot Water Valve');
+      this.valveService = new Service.Valve( this.accessory.displayName + ' Valve', this.accessory.displayName + ' Sub');
       
       this.valveService.addCharacteristic(Characteristic.ConfiguredName);
   
       this.valveService
-        .setCharacteristic(Characteristic.Name, 'Hot Water')
+        .setCharacteristic(Characteristic.Name, this.accessory.displayName + ' Valve')
         .setCharacteristic(Characteristic.ServiceLabelIndex, 1)
-        .setCharacteristic(Characteristic.ConfiguredName, 'Hot Water')
+        .setCharacteristic(Characteristic.ConfiguredName, this.accessory.displayName + ' Valve')
         .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
         .setCharacteristic(Characteristic.ValveType, Characteristic.ValveType.WATER_FAUCET);
         
@@ -58,7 +58,7 @@ class thermostat_Accessory {
             
     } else {
   
-      this.valveService = this.accessory.getServiceByUUIDAndSubType(Service.Valve, 'Hot Water Valve');  
+      this.valveService = this.accessory.getServiceByUUIDAndSubType(Service.Valve, this.accessory.displayName + ' Valve');  
       this.mainService.addLinkedService(this.valveService);
         
     }
@@ -151,7 +151,8 @@ class thermostat_Accessory {
     
     } finally {
   
-      if(!this.accessory.context.remove) setTimeout(this.getState.bind(this), this.accessory.context.polling);
+      if(!this.accessory.context.remove) 
+        setTimeout(this.getState.bind(this), this.accessory.context.polling);
       
     }
   

--- a/src/accessories/thermostat.js
+++ b/src/accessories/thermostat.js
@@ -511,10 +511,6 @@ class thermostat_Accessory {
   
         service.getCharacteristic(Characteristic.TargetTemperature).setValue(value, undefined, 'rule'); 
   
-      } else {
-  
-        this.debug(accessory.displayName + ': Ignoring temperature adjustment due to rule or scene!'); 
-  
       }
     
       callback();

--- a/src/accessories/thermostat.js
+++ b/src/accessories/thermostat.js
@@ -123,52 +123,48 @@ class thermostat_Accessory {
       .on('get', function(callback){
         callback(null, accessory.context.coolValue);
       });
-    
-    if(accessory.context.zoneType === 'HEATING'){ 
      
-      if (!service.testCharacteristic(Characteristic.HeatingPower))
-        service.addCharacteristic(Characteristic.HeatingPower);
+    if (!service.testCharacteristic(Characteristic.HeatingPower))
+      service.addCharacteristic(Characteristic.HeatingPower);
       
-      service.getCharacteristic(Characteristic.HeatingPower)
-        .on('change', function(value){
-          self.logger.info(accessory.displayName + ': Heating power changed to ' + value.newValue + '%');
-        });
+    service.getCharacteristic(Characteristic.HeatingPower)
+      .on('change', function(value){
+        self.logger.info(accessory.displayName + ': Heating power changed to ' + value.newValue + '%');
+      });
     
-      service.getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on('change', function(value){
-          self.historyService.addEntry({time: moment().unix(), temp:accessory.context.currentTemp, pressure:0, humidity:value.newValue});
-          self.debug(accessory.displayName + ': New entry: ' + accessory.context.currentTemp + ' for temperature and ' + value.newValue + ' for humidity');
-        });
+    service.getCharacteristic(Characteristic.CurrentRelativeHumidity)
+      .on('change', function(value){
+        self.historyService.addEntry({time: moment().unix(), temp:accessory.context.currentTemp, pressure:0, humidity:value.newValue});
+        self.debug(accessory.displayName + ': New entry: ' + accessory.context.currentTemp + ' for temperature and ' + value.newValue + ' for humidity');
+      });
 
-      if (!service.testCharacteristic(Characteristic.DelayTimer))
-        service.addCharacteristic(Characteristic.DelayTimer);
+    if (!service.testCharacteristic(Characteristic.DelayTimer))
+      service.addCharacteristic(Characteristic.DelayTimer);
       
-      service.getCharacteristic(Characteristic.DelayTimer)
-        .setProps({
-          minValue: 0,
-          maxValue: accessory.context.maxDelay,
-          minStep: 1
-        })
-        .on('set', function(value, callback){
-          self.logger.info(accessory.displayName + ': Setting delay to ' + value);
-          accessory.context.delay = value;
-          callback(null, value);
-        })
-        .on('get', function(callback){
-          callback(null, accessory.context.delay);
-        });
+    service.getCharacteristic(Characteristic.DelayTimer)
+      .setProps({
+        minValue: 0,
+        maxValue: accessory.context.maxDelay,
+        minStep: 1
+      })
+      .on('set', function(value, callback){
+        self.logger.info(accessory.displayName + ': Setting delay to ' + value);
+        accessory.context.delay = value;
+        callback(null, value);
+      })
+      .on('get', function(callback){
+        callback(null, accessory.context.delay);
+      });
         
         
-      if (!service.testCharacteristic(Characteristic.DelaySwitch))
-        service.addCharacteristic(Characteristic.DelaySwitch);
+    if (!service.testCharacteristic(Characteristic.DelaySwitch))
+      service.addCharacteristic(Characteristic.DelaySwitch);
       
-      service.getCharacteristic(Characteristic.DelaySwitch)
-        .on('set', self.setDelay.bind(this, accessory, service))
-        .on('get', function(callback){
-          callback(null, accessory.context.delayState);
-        });
-        
-    }
+    service.getCharacteristic(Characteristic.DelaySwitch)
+      .on('set', self.setDelay.bind(this, accessory, service))
+      .on('get', function(callback){
+        callback(null, accessory.context.delayState);
+      });
         
     battery.getCharacteristic(Characteristic.ChargingState)
       .updateValue(2); //Not chargable
@@ -246,98 +242,45 @@ class thermostat_Accessory {
       
       let targetTemp, currentState, targetState, batteryLevel, statusLowBattery, device;
       
-      if(accessory.context.zoneType === 'HEATING') {
-      
-        if(zone.activityDataPoints && Object.keys(zone.activityDataPoints).length)
-          service.getCharacteristic(Characteristic.HeatingPower).updateValue(zone.activityDataPoints.heatingPower.percentage);
+      if(zone.activityDataPoints && Object.keys(zone.activityDataPoints).length)
+        service.getCharacteristic(Characteristic.HeatingPower).updateValue(zone.activityDataPoints.heatingPower.percentage);
         
-        accessory.context.currentTemp = ( accessory.context.unit === 1 )? zone.sensorDataPoints.insideTemperature.fahrenheit : zone.sensorDataPoints.insideTemperature.celsius;
-        accessory.context.currentHumidity = zone.sensorDataPoints.humidity.percentage;
+      accessory.context.currentTemp = ( accessory.context.unit === 1 )? zone.sensorDataPoints.insideTemperature.fahrenheit : zone.sensorDataPoints.insideTemperature.celsius;
+      accessory.context.currentHumidity = zone.sensorDataPoints.humidity.percentage;
        
-        if(zone.setting.power === 'OFF') {
+      if(zone.setting.power === 'OFF') {
        
-          targetTemp = ( accessory.context.unit === 1 ) ? zone.sensorDataPoints.insideTemperature.fahrenheit : zone.sensorDataPoints.insideTemperature.celsius;
-          currentState = 0;
-          targetState = 0;
+        targetTemp = ( accessory.context.unit === 1 ) ? zone.sensorDataPoints.insideTemperature.fahrenheit : zone.sensorDataPoints.insideTemperature.celsius;
+        currentState = 0;
+        targetState = 0;
        
-        } else {
+      } else {
        
-          targetTemp = ( accessory.context.unit === 1 )? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius; 
+        targetTemp = ( accessory.context.unit === 1 )? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius; 
       
-          if(zone.overlayType === 'MANUAL'){
+        if(zone.overlayType === 'MANUAL'){
       
-            if(Math.round(accessory.context.currentTemp) < Math.round(targetTemp)){
+          if(Math.round(accessory.context.currentTemp) < Math.round(targetTemp)){
      
-              currentState = 1;
-              targetState = 1;
+            currentState = 1;
+            targetState = 1;
      
-            } else {
- 
-              currentState = 2;
-              targetState = 2;
- 
-            }
-      
           } else {
+ 
+            currentState = 2;
+            targetState = 2;
+ 
+          }
+      
+        } else {
               
-            accessory.context.autoTempValue = accessory.context.unit === 1 ? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius;
+          accessory.context.autoTempValue = accessory.context.unit === 1 ? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius;
       
-            targetState = 3;
-            currentState = 0;
-      
-          }
-       
-        }
-        
-      } else { //accessory.context.zoneType === 'HOT_WATER'
-    
-        // Current Temperature = Target Temperature , no temperature measurement
-     
-        accessory.context.currentTemp = accessory.context.currentTemp ? accessory.context.currentTemp : 0;
-        accessory.context.tarTemp = accessory.context.tarTemp ? accessory.context.tarTemp : 0;
-        accessory.context.cachedTemp = accessory.context.cachedTemp ? accessory.context.cachedTemp : 0;
-       
-        if(zone.setting.power === 'OFF') {
-       
+          targetState = 3;
           currentState = 0;
-          targetState = 0;
-       
-        } else {
-          
-          accessory.context.currentTemp = ( accessory.context.unit === 1 ) ? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius;
-          accessory.context.tarTemp = ( accessory.context.unit === 1 ) ? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius;
-          
-          if(zone.overlayType === 'MANUAL'){
       
-            if(Math.round(accessory.context.cachedTemp) < Math.round(accessory.context.tarTemp)){
-
-              accessory.context.cachedTemp = accessory.context.tarTemp;
-
-              currentState = 1;
-              targetState = 1;
-     
-            } else {
-
-              accessory.context.cachedTemp = accessory.context.tarTemp;
- 
-              currentState = 2;
-              targetState = 2;
- 
-            }
-      
-          } else {
-            
-            accessory.context.autoTempValue = accessory.context.unit === 1 ? zone.setting.temperature.fahrenheit : zone.setting.temperature.celsius;
-      
-            targetState = 3;
-            currentState = 0;
-      
-          }
-       
         }
-        
-        targetTemp = accessory.context.tarTemp;
-        
+       
       }
       
       device = await this.tadoHandler.getDevice(accessory.context.serial);
@@ -353,8 +296,7 @@ class thermostat_Accessory {
       service.getCharacteristic(Characteristic.CurrentTemperature).updateValue(accessory.context.currentTemp);
       service.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
       
-      if(accessory.context.zoneType === 'HEATING')
-        service.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(accessory.context.currentHumidity);
+      service.getCharacteristic(Characteristic.CurrentRelativeHumidity).updateValue(accessory.context.currentHumidity);
       
       service.getCharacteristic(Characteristic.TemperatureDisplayUnits).updateValue(accessory.context.unit);      
       
@@ -571,7 +513,7 @@ class thermostat_Accessory {
   
       } else {
   
-        this.logger.warn(accessory.displayName + ': Ignoring temperature adjustment due to rule or scene!'); 
+        this.debug(accessory.displayName + ': Ignoring temperature adjustment due to rule or scene!'); 
   
       }
     

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -5,7 +5,7 @@ const inherits = require('util').inherits;
 module.exports = {
   registerWith: function (hap) {
     const Characteristic = hap.Characteristic;
-    //const Service = hap.Service;
+    const Service = hap.Service;
 
     /// /////////////////////////////////////////////////////////////////////////
     // AutoThermostats Characteristic
@@ -157,6 +157,26 @@ module.exports = {
     };
     inherits(Characteristic.DummySwitch, Characteristic);
     Characteristic.DummySwitch.UUID = 'a33a7443-ec88-4760-a48e-cff68f78e6d3';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Faucet Service
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Service.Faucet = function(displayName, subtype) {
+      Service.call(this, displayName, '000000D7-0000-1000-8000-0026BB765291', subtype);
+      
+      // Required Characteristics
+      this.addCharacteristic(Characteristic.Active);
+
+      // Optional Characteristics
+      this.addOptionalCharacteristic(Characteristic.Name);
+      this.addOptionalCharacteristic(Characteristic.StatusFault);
+      this.addOptionalCharacteristic(Characteristic.CurrentHeaterCoolerState);
+      this.addOptionalCharacteristic(Characteristic.TargetHeaterCoolerState);
+      this.addOptionalCharacteristic(Characteristic.HeatingThresholdTemperature);
+    
+    };
+    inherits(Service.Faucet, Service);
+    Service.Faucet.UUID = '000000D7-0000-1000-8000-0026BB765291';
     
     
   }


### PR DESCRIPTION
- Refactored HOTWATER Accessory (*)
- Bugfixes
- Cleanup code

(*) Added Faucet Accessory with temperature control for HOTWATER (only for devices with temperature adjustment capability). If you have HOTWATER devices with these capability, you need to remove this device from your Cache by setting "active":false into your config.json under the device before updating (IMPORTANT)!