### PR TITLE
reduce the polling interval to the tado backend

### DIFF
--- a/homebridge-ui/public/js/main.js
+++ b/homebridge-ui/public/js/main.js
@@ -1071,7 +1071,7 @@ async function fetchDevices(credentials, refresh, resync){
             name: foundHome.name,
             username: foundHome.username,
             password: foundHome.password,
-            polling: 30,
+            polling: 300,
             zones: [],
             presence: {
               anyone: false,
@@ -1230,7 +1230,7 @@ async function fetchDevices(credentials, refresh, resync){
             name: foundHome.name,
             username: credentials.username,
             password: credentials.password, 
-            polling: 30,
+            polling: 300,
             zones: [],
             presence: {
               anyone: false,

--- a/homebridge-ui/public/js/schema.js
+++ b/homebridge-ui/public/js/schema.js
@@ -44,8 +44,8 @@ const schema = {
           'title': 'Polling',
           'description': 'The polling interval in seconds.',
           'type': 'integer',
-          'default': 30,
-          'minimum': 30
+          'default': 300,
+          'minimum': 300
         },
         'temperatureUnit': {
           'title': 'Temperature Unit',

--- a/src/tado/tado-config.js
+++ b/src/tado/tado-config.js
@@ -49,7 +49,7 @@ module.exports = {
             name: foundHome.name,
             username: username,
             password: password,
-            polling: 30,
+            polling: 300,
             zones: [],
             presence: {
               anyone: false,
@@ -540,7 +540,7 @@ module.exports = {
               home.extras && home.extras.childLockSwitches
                 ? home.extras.childLockSwitches.filter((childLockSwitch) => childLockSwitch && childLockSwitch.active)
                 : [],
-            polling: Number.isInteger(home.polling) ? (home.polling < 30 ? 30 : home.polling) : 30,
+            polling: Number.isInteger(home.polling) ? (home.polling < 300 ? 300 : home.polling) : 300,
           };
 
           if (home.zones && home.zones.length) {


### PR DESCRIPTION
To avoid breaking the integration due to changes in the rate limiting in the tado API, the interval of how often the backend API is called is reduced.