### PR TITLE
Fix: multiple child bridges with distinct accounts all auth as the first account

### DIFF
--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -33,6 +33,22 @@
     <h6 class="m-0 p-0">Custom UI cannot be displayed. The used Config UI X version is not supported!</h6>
   </div>
 
+  <!-- selectBridge: shown only when this plugin has multiple platform entries
+       (e.g. several child bridges). Lets the user pick which one this UI
+       session will configure so that newly added homes don't all funnel into
+       platforms[0]. -->
+  <div id="selectBridge" style="display:none;">
+    <img src="images/tado_logo.png" alt="tado meets Homebridge" width="150px" class="center-it mt-2 tadoLogo">
+    <h6 class="text-center">You have multiple Tado bridge instances configured.<br>Pick the one you want to configure now.</h6>
+    <div class="container mt-4" style="max-width: 360px;">
+      <div class="form-group">
+        <label for="bridgeSelectChoice">Bridge</label>
+        <select class="custom-select" id="bridgeSelectChoice"></select>
+      </div>
+      <button id="bridgeSelectContinue" type="submit" class="btn btn-primary float-right mt-3 mr-0">Continue</button>
+    </div>
+  </div>
+
   <!-- isConfigured -->
   <div id="isConfigured" style="display:none;">
     <button type="submit" class="btn btn-elegant oldConfig" style="position: absolute;">

--- a/homebridge-ui/public/js/main.js
+++ b/homebridge-ui/public/js/main.js
@@ -355,9 +355,15 @@ async function fetchDevices(auth, refresh, resync) {
       homebridge.request('/authenticate', params);
       const instructionsURL = await homebridge.request('/exec', { dest: 'fullAuthentication' });
       if (instructionsURL && instructionsURL !== "") {
-        $("#fetchDevices #authenticationInstructions").html(`Open the following URL in your browser, click "submit" and log in to your tado° account "${params.username}": <a href="${instructionsURL}" target ="_blank">${instructionsURL}</a>`);
+        $("#fetchDevices #authenticationInstructions").html(
+          `<strong style="color:#c00;">Important:</strong> open this URL in a <strong>private / incognito window</strong>` +
+          ` (or sign out of <a href="https://app.tado.com" target="_blank">app.tado.com</a> first).` +
+          `<br>If your browser is still signed in as a different tado° account, clicking "Submit" will silently confirm THAT account — not <strong>${params.username}</strong>.` +
+          `<br><br>Sign in as <strong>${params.username}</strong> and click "Submit":` +
+          `<br><a href="${instructionsURL}" target="_blank" rel="noopener noreferrer">${instructionsURL}</a>`
+        );
         $("#fetchDevices #authenticationInstructions").css("display", "block");
-        homebridge.toast.info("Please follow the instructions above and confirm your login.");
+        homebridge.toast.info("Open the link in a private/incognito window and confirm your login.");
         const authenticationSuccessful = await homebridge.request('/exec', { dest: 'waitForAuthentication' });
         $("#fetchDevices #authenticationInstructions").html("");
         $("#fetchDevices #authenticationInstructions").css("display", "none");

--- a/homebridge-ui/public/js/main.js
+++ b/homebridge-ui/public/js/main.js
@@ -7,7 +7,38 @@ const pageNavigation = {
 
 let customSchemaActive = false;
 let pluginConfig = false;
+let activeIndex = 0;
 let currentHome = false;
+
+function bridgeLabel(entry, i) {
+  const name = entry && entry.name;
+  const childUsername = entry && entry._bridge && entry._bridge.username;
+  if (name && childUsername) return `${name} (child bridge ${childUsername})`;
+  if (name) return name;
+  if (childUsername) return `Child bridge ${childUsername}`;
+  return `Bridge ${i + 1}`;
+}
+
+async function chooseActiveBridge() {
+  if (!pluginConfig || pluginConfig.length <= 1) return;
+  const $select = $('#bridgeSelectChoice');
+  $select.empty();
+  pluginConfig.forEach((entry, i) => {
+    const homeCount = (entry && entry.homes && entry.homes.length) || 0;
+    const homesLabel = `${homeCount} home${homeCount === 1 ? '' : 's'}`;
+    $select.append(`<option value="${i}">${bridgeLabel(entry, i)} — ${homesLabel}</option>`);
+  });
+  $select.val(String(activeIndex));
+  await new Promise(resolve => {
+    $('#bridgeSelectContinue').off('click').on('click', () => {
+      const parsed = parseInt($select.val(), 10);
+      activeIndex = Number.isInteger(parsed) ? parsed : 0;
+      $('#selectBridge').hide();
+      resolve();
+    });
+    $('#selectBridge').fadeIn(250);
+  });
+}
 
 const TIMEOUT = (ms) => new Promise((res) => setTimeout(res, ms));
 
@@ -130,20 +161,20 @@ async function createCustomSchema(home) {
   //schema.layout.homes.forEach()
 
   customSchemaActive = homebridge.createForm(schema, {
-    name: pluginConfig[0].name,
-    debug: pluginConfig[0].debug,
-    disableHistoryService: pluginConfig[0].disableHistoryService,
-    preferSiriTemperature: pluginConfig[0].preferSiriTemperature,
+    name: pluginConfig[activeIndex].name,
+    debug: pluginConfig[activeIndex].debug,
+    disableHistoryService: pluginConfig[activeIndex].disableHistoryService,
+    preferSiriTemperature: pluginConfig[activeIndex].preferSiriTemperature,
     homes: home
   });
 
   customSchemaActive.onChange(async config => {
 
-    pluginConfig[0].name = config.name;
-    pluginConfig[0].debug = config.debug;
-    pluginConfig[0].disableHistoryService = config.disableHistoryService;
-    pluginConfig[0].preferSiriTemperature = config.preferSiriTemperature;
-    pluginConfig[0].homes = pluginConfig[0].homes.map(myHome => {
+    pluginConfig[activeIndex].name = config.name;
+    pluginConfig[activeIndex].debug = config.debug;
+    pluginConfig[activeIndex].disableHistoryService = config.disableHistoryService;
+    pluginConfig[activeIndex].preferSiriTemperature = config.preferSiriTemperature;
+    pluginConfig[activeIndex].homes = pluginConfig[activeIndex].homes.map(myHome => {
       if (myHome.name === config.homes.name) {
         myHome = config.homes;
       }
@@ -228,21 +259,21 @@ async function addNewDeviceToConfig(config, refresh, resync) {
 
   try {
 
-    for (const i in config[0].homes) {
+    for (const i in config[activeIndex].homes) {
 
       let found = false;
 
-      for (const j in pluginConfig[0].homes)
-        if (config[0].homes[i].name === pluginConfig[0].homes[j].name)
+      for (const j in pluginConfig[activeIndex].homes)
+        if (config[activeIndex].homes[i].name === pluginConfig[activeIndex].homes[j].name)
           found = true;
 
       if (!found) {
-        addDeviceToList(config[0].homes[i]);
-        homebridge.toast.success(config[0].homes[i].name + ' added to config!', 'Success');
+        addDeviceToList(config[activeIndex].homes[i]);
+        homebridge.toast.success(config[activeIndex].homes[i].name + ' added to config!', 'Success');
       } else if (refresh) {
-        homebridge.toast.success(config[0].homes[i].name + ' refreshed!', 'Success');
+        homebridge.toast.success(config[activeIndex].homes[i].name + ' refreshed!', 'Success');
       } else if (resync) {
-        homebridge.toast.success(config[0].homes[i].name + ' resynchronized!', 'Success');
+        homebridge.toast.success(config[activeIndex].homes[i].name + ' resynchronized!', 'Success');
       }
 
     }
@@ -270,7 +301,7 @@ async function removeDeviceFromConfig(name) {
   let foundIndex;
   let pluginConfigBkp = JSON.parse(JSON.stringify(pluginConfig));
 
-  pluginConfig[0].homes.forEach((home, index) => {
+  pluginConfig[activeIndex].homes.forEach((home, index) => {
     if (home.name === currentHome) {
       foundIndex = index;
     }
@@ -280,13 +311,13 @@ async function removeDeviceFromConfig(name) {
 
     try {
 
-      pluginConfig[0].homes.splice(foundIndex, 1);
+      pluginConfig[activeIndex].homes.splice(foundIndex, 1);
       removeDeviceFromList(currentHome);
 
-      if (!pluginConfig[0].homes.length) {
-        delete pluginConfig[0].debug;
-        delete pluginConfig[0].disableHistoryService;
-        delete pluginConfig[0].preferSiriTemperature;
+      if (!pluginConfig[activeIndex].homes.length) {
+        delete pluginConfig[activeIndex].debug;
+        delete pluginConfig[activeIndex].disableHistoryService;
+        delete pluginConfig[activeIndex].preferSiriTemperature;
       }
 
       await homebridge.updatePluginConfig(pluginConfig);
@@ -348,7 +379,7 @@ async function fetchDevices(auth, refresh, resync) {
       //refresh selected home
 
       //Home Informations
-      let home = config[0].homes.find(home => home && home.name === currentHome);
+      let home = config[activeIndex].homes.find(home => home && home.name === currentHome);
 
       if (!home)
         return homebridge.toast.error('Cannot refresh ' + currentHome + '. Not found in config!', 'Error');
@@ -371,26 +402,26 @@ async function fetchDevices(auth, refresh, resync) {
 
       const homeInfo = await homebridge.request('/exec', { dest: 'getHome', data: home.id });
 
-      for (let [i, home] of config[0].homes.entries()) {
+      for (let [i, home] of config[activeIndex].homes.entries()) {
 
-        if (config[0].homes[i].name === homeInfo.name) {
+        if (config[activeIndex].homes[i].name === homeInfo.name) {
 
-          config[0].homes[i].id = homeInfo.id;
-          config[0].homes[i].username = auth.username;
-          config[0].homes[i].tadoApiUrl = auth.tadoApiUrl;
-          config[0].homes[i].skipAuth = auth.skipAuth;
-          config[0].homes[i].temperatureUnit = homeInfo.temperatureUnit || 'CELSIUS';
-          config[0].homes[i].zones = config[0].homes[i].zones || [];
+          config[activeIndex].homes[i].id = homeInfo.id;
+          config[activeIndex].homes[i].username = auth.username;
+          config[activeIndex].homes[i].tadoApiUrl = auth.tadoApiUrl;
+          config[activeIndex].homes[i].skipAuth = auth.skipAuth;
+          config[activeIndex].homes[i].temperatureUnit = homeInfo.temperatureUnit || 'CELSIUS';
+          config[activeIndex].homes[i].zones = config[activeIndex].homes[i].zones || [];
 
           if (homeInfo.geolocation)
-            config[0].homes[i].geolocation = {
+            config[activeIndex].homes[i].geolocation = {
               longitude: homeInfo.geolocation.longitude.toString(),
               latitude: homeInfo.geolocation.latitude.toString()
             };
 
           //init devices for childLock
-          config[0].homes[i].extras = config[0].homes[i].extras || {};
-          config[0].homes[i].extras.childLockSwitches = config[0].homes[i].extras.childLockSwitches || [];
+          config[activeIndex].homes[i].extras = config[activeIndex].homes[i].extras || {};
+          config[activeIndex].homes[i].extras.childLockSwitches = config[activeIndex].homes[i].extras.childLockSwitches || [];
 
           let allFoundDevices = [];
 
@@ -401,15 +432,15 @@ async function fetchDevices(auth, refresh, resync) {
           //Mobile Devices Informations
           const mobileDevices = await homebridge.request('/exec', { dest: 'getMobileDevices', data: home.id });
 
-          if (!config[0].homes[i].presence)
-            config[0].homes[i].presence = {
+          if (!config[activeIndex].homes[i].presence)
+            config[activeIndex].homes[i].presence = {
               anyone: false,
               accTypeAnyone: 'OCCUPANCY',
               user: []
             };
 
           //Remove not registred devices
-          config[0].homes[i].presence.user.forEach((user, index) => {
+          config[activeIndex].homes[i].presence.user.forEach((user, index) => {
             let found = false;
             mobileDevices.forEach(foundUser => {
               if (foundUser.name === user.name) {
@@ -418,21 +449,21 @@ async function fetchDevices(auth, refresh, resync) {
             });
             if (!found) {
               homebridge.toast.info(user.name + ' removed from config!', auth.username);
-              config[0].homes[i].presence.user.splice(index, 1);
+              config[activeIndex].homes[i].presence.user.splice(index, 1);
             }
           });
 
           //Check for new registred devices
-          if (config[0].homes[i].presence.user.length) {
+          if (config[activeIndex].homes[i].presence.user.length) {
             for (const foundUser of mobileDevices) {
               let userIndex;
-              config[0].homes[i].presence.user.forEach((user, index) => {
+              config[activeIndex].homes[i].presence.user.forEach((user, index) => {
                 if (user.name === foundUser.name) {
                   userIndex = index;
                 }
               });
               if (userIndex === undefined) {
-                config[0].homes[i].presence.user.push({
+                config[activeIndex].homes[i].presence.user.push({
                   active: false,
                   name: foundUser.name,
                   accType: 'OCCUPANCY'
@@ -440,7 +471,7 @@ async function fetchDevices(auth, refresh, resync) {
               }
             }
           } else {
-            config[0].homes[i].presence.user = mobileDevices.map(user => {
+            config[activeIndex].homes[i].presence.user = mobileDevices.map(user => {
               return {
                 active: false,
                 name: user.name,
@@ -457,7 +488,7 @@ async function fetchDevices(auth, refresh, resync) {
           const zones = await homebridge.request('/exec', { dest: 'getZones', data: home.id });
 
           //Remove not available zones
-          config[0].homes[i].zones.forEach((zone, index) => {
+          config[activeIndex].homes[i].zones.forEach((zone, index) => {
             let found = false;
             zones.forEach(foundZone => {
               if (foundZone.name === zone.name) {
@@ -466,12 +497,12 @@ async function fetchDevices(auth, refresh, resync) {
             });
             if (!found) {
               homebridge.toast.info(zone.name + ' removed from config!', auth.username);
-              config[0].homes[i].zones.splice(index, 1);
+              config[activeIndex].homes[i].zones.splice(index, 1);
             }
           });
 
           //Check for new zones or refresh exist one
-          if (config[0].homes[i].zones.length) {
+          if (config[activeIndex].homes[i].zones.length) {
             for (const foundZone of zones) {
 
               const capabilities = await homebridge.request('/exec', { dest: 'getZoneCapabilities', data: [home.id, foundZone.id] }) || {};
@@ -516,19 +547,19 @@ async function fetchDevices(auth, refresh, resync) {
                 });
 
               let zoneIndex;
-              config[0].homes[i].zones.forEach((zone, index) => {
+              config[activeIndex].homes[i].zones.forEach((zone, index) => {
                 if (zone.name === foundZone.name) {
                   zoneIndex = index;
                 }
               });
               if (zoneIndex !== undefined) {
-                config[0].homes[i].zones[zoneIndex].id = foundZone.id;
-                config[0].homes[i].zones[zoneIndex].type = foundZone.type;
-                config[0].homes[i].zones[zoneIndex].minValue = minTempValue;
-                config[0].homes[i].zones[zoneIndex].maxValue = maxTempValue;
-                config[0].homes[i].zones[zoneIndex].minStep = minTempStep;
+                config[activeIndex].homes[i].zones[zoneIndex].id = foundZone.id;
+                config[activeIndex].homes[i].zones[zoneIndex].type = foundZone.type;
+                config[activeIndex].homes[i].zones[zoneIndex].minValue = minTempValue;
+                config[activeIndex].homes[i].zones[zoneIndex].maxValue = maxTempValue;
+                config[activeIndex].homes[i].zones[zoneIndex].minStep = minTempStep;
               } else {
-                config[0].homes[i].zones.push({
+                config[activeIndex].homes[i].zones.push({
                   active: true,
                   id: foundZone.id,
                   name: foundZone.name,
@@ -595,7 +626,7 @@ async function fetchDevices(auth, refresh, resync) {
                   });
                 });
 
-              config[0].homes[i].zones.push({
+              config[activeIndex].homes[i].zones.push({
                 active: true,
                 id: zone.id,
                 name: zone.name,
@@ -621,7 +652,7 @@ async function fetchDevices(auth, refresh, resync) {
           }
 
           //remove non existing childLockSwitches
-          config[0].homes[i].extras.childLockSwitches.forEach((childLockSwitch, index) => {
+          config[activeIndex].homes[i].extras.childLockSwitches.forEach((childLockSwitch, index) => {
             let found = false;
             allFoundDevices.forEach(foundDevice => {
               if (foundDevice.serialNumber === childLockSwitch.serialNumber) {
@@ -630,21 +661,21 @@ async function fetchDevices(auth, refresh, resync) {
             });
             if (!found) {
               homebridge.toast.info(childLockSwitch.name + ' removed from config!', auth.username);
-              config[0].homes[i].extras.childLockSwitches.splice(index, 1);
+              config[activeIndex].homes[i].extras.childLockSwitches.splice(index, 1);
             }
           });
 
           //check for new childLockSwitches
-          if (config[0].homes[i].extras.childLockSwitches.length) {
+          if (config[activeIndex].homes[i].extras.childLockSwitches.length) {
             for (const foundDevice of allFoundDevices) {
               let found = false;
-              config[0].homes[i].extras.childLockSwitches.forEach(childLockSwitch => {
+              config[activeIndex].homes[i].extras.childLockSwitches.forEach(childLockSwitch => {
                 if (childLockSwitch.serialNumber === foundDevice.serialNumber) {
                   found = true;
                 }
               });
               if (!found) {
-                config[0].homes[i].extras.childLockSwitches.push({
+                config[activeIndex].homes[i].extras.childLockSwitches.push({
                   active: false,
                   name: foundDevice.name,
                   serialNumber: foundDevice.serialNumber
@@ -652,7 +683,7 @@ async function fetchDevices(auth, refresh, resync) {
               }
             }
           } else {
-            config[0].homes[i].extras.childLockSwitches = allFoundDevices.map(device => {
+            config[activeIndex].homes[i].extras.childLockSwitches = allFoundDevices.map(device => {
               return {
                 active: false,
                 name: device.name,
@@ -671,7 +702,7 @@ async function fetchDevices(auth, refresh, resync) {
 
       const availableHomesInApis = [];
 
-      for (let home of config[0].homes) {
+      for (let home of config[activeIndex].homes) {
 
         if (home.name && home.username) {
 
@@ -710,7 +741,7 @@ async function fetchDevices(auth, refresh, resync) {
       let removedHomes = 0;
 
       //remove non exist homes from config that doesnt exist in api
-      for (let [i, home] of config[0].homes.entries()) {
+      for (let [i, home] of config[activeIndex].homes.entries()) {
 
         if (home.name && home.username) {
 
@@ -734,7 +765,7 @@ async function fetchDevices(auth, refresh, resync) {
             homebridge.toast.info(home.name + ' removed from config!', home.username);
 
             await removeDeviceFromConfig(home.name);
-            config[0].homes.splice(i, 1);
+            config[activeIndex].homes.splice(i, 1);
 
             removedHomes += 1;
 
@@ -754,7 +785,7 @@ async function fetchDevices(auth, refresh, resync) {
       await TIMEOUT(2000);
 
       //refresh existing homes
-      for (let [i, home] of config[0].homes.entries()) {
+      for (let [i, home] of config[activeIndex].homes.entries()) {
 
         if (home.name && home.username) {
 
@@ -780,37 +811,37 @@ async function fetchDevices(auth, refresh, resync) {
 
             const homeInfo = await homebridge.request('/exec', { dest: 'getHome', data: home.id });
 
-            config[0].homes[i].id = homeInfo.id;
-            config[0].homes[i].username = foundHome.username;
-            config[0].homes[i].tadoApiUrl = foundHome.tadoApiUrl;
-            config[0].homes[i].skipAuth = foundHome.skipAuth;
-            config[0].homes[i].temperatureUnit = homeInfo.temperatureUnit || 'CELSIUS';
-            config[0].homes[i].zones = config[0].homes[i].zones || [];
+            config[activeIndex].homes[i].id = homeInfo.id;
+            config[activeIndex].homes[i].username = foundHome.username;
+            config[activeIndex].homes[i].tadoApiUrl = foundHome.tadoApiUrl;
+            config[activeIndex].homes[i].skipAuth = foundHome.skipAuth;
+            config[activeIndex].homes[i].temperatureUnit = homeInfo.temperatureUnit || 'CELSIUS';
+            config[activeIndex].homes[i].zones = config[activeIndex].homes[i].zones || [];
 
             if (homeInfo.geolocation)
-              config[0].homes[i].geolocation = {
+              config[activeIndex].homes[i].geolocation = {
                 longitude: homeInfo.geolocation.longitude.toString(),
                 latitude: homeInfo.geolocation.latitude.toString()
               };
 
             //init devices for childLock
-            config[0].homes[i].extras = config[0].homes[i].extras || {};
-            config[0].homes[i].extras.childLockSwitches = config[0].homes[i].extras.childLockSwitches || [];
+            config[activeIndex].homes[i].extras = config[activeIndex].homes[i].extras || {};
+            config[activeIndex].homes[i].extras.childLockSwitches = config[activeIndex].homes[i].extras.childLockSwitches || [];
 
             let allFoundDevices = [];
 
             //Mobile Devices Informations
             const mobileDevices = await homebridge.request('/exec', { dest: 'getMobileDevices', data: home.id });
 
-            if (!config[0].homes[i].presence)
-              config[0].homes[i].presence = {
+            if (!config[activeIndex].homes[i].presence)
+              config[activeIndex].homes[i].presence = {
                 anyone: false,
                 accTypeAnyone: 'OCCUPANCY',
                 user: []
               };
 
             //Remove not registred devices
-            config[0].homes[i].presence.user.forEach((user, index) => {
+            config[activeIndex].homes[i].presence.user.forEach((user, index) => {
               let found = false;
               mobileDevices.forEach(foundUser => {
                 if (foundUser.name === user.name) {
@@ -819,21 +850,21 @@ async function fetchDevices(auth, refresh, resync) {
               });
               if (!found) {
                 homebridge.toast.info(user.name + ' removed from config!', home.username);
-                config[0].homes[i].presence.user.splice(index, 1);
+                config[activeIndex].homes[i].presence.user.splice(index, 1);
               }
             });
 
             //Check for new registred devices
-            if (config[0].homes[i].presence.user.length) {
+            if (config[activeIndex].homes[i].presence.user.length) {
               for (const foundUser of mobileDevices) {
                 let userIndex;
-                config[0].homes[i].presence.user.forEach((user, index) => {
+                config[activeIndex].homes[i].presence.user.forEach((user, index) => {
                   if (user.name === foundUser.name) {
                     userIndex = index;
                   }
                 });
                 if (userIndex === undefined) {
-                  config[0].homes[i].presence.user.push({
+                  config[activeIndex].homes[i].presence.user.push({
                     active: false,
                     name: foundUser.name,
                     accType: 'OCCUPANCY'
@@ -841,7 +872,7 @@ async function fetchDevices(auth, refresh, resync) {
                 }
               }
             } else {
-              config[0].homes[i].presence.user = mobileDevices.map(user => {
+              config[activeIndex].homes[i].presence.user = mobileDevices.map(user => {
                 return {
                   active: false,
                   name: user.name,
@@ -854,7 +885,7 @@ async function fetchDevices(auth, refresh, resync) {
             const zones = await homebridge.request('/exec', { dest: 'getZones', data: home.id });
 
             //Remove not available zones
-            config[0].homes[i].zones.forEach((zone, index) => {
+            config[activeIndex].homes[i].zones.forEach((zone, index) => {
               let found = false;
               zones.forEach(foundZone => {
                 if (foundZone.name === zone.name) {
@@ -863,12 +894,12 @@ async function fetchDevices(auth, refresh, resync) {
               });
               if (!found) {
                 homebridge.toast.info(zone.name + ' removed from config!', home.username);
-                config[0].homes[i].zones.splice(index, 1);
+                config[activeIndex].homes[i].zones.splice(index, 1);
               }
             });
 
             //Check for new zones or refresh exist one
-            if (config[0].homes[i].zones.length) {
+            if (config[activeIndex].homes[i].zones.length) {
               for (const foundZone of zones) {
 
                 const capabilities = await homebridge.request('/exec', { dest: 'getZoneCapabilities', data: [home.id, foundZone.id] }) || {};
@@ -913,19 +944,19 @@ async function fetchDevices(auth, refresh, resync) {
                   });
 
                 let zoneIndex;
-                config[0].homes[i].zones.forEach((zone, index) => {
+                config[activeIndex].homes[i].zones.forEach((zone, index) => {
                   if (zone.name === foundZone.name) {
                     zoneIndex = index;
                   }
                 });
                 if (zoneIndex !== undefined) {
-                  config[0].homes[i].zones[zoneIndex].id = foundZone.id;
-                  config[0].homes[i].zones[zoneIndex].type = foundZone.type;
-                  config[0].homes[i].zones[zoneIndex].minValue = minTempValue;
-                  config[0].homes[i].zones[zoneIndex].maxValue = maxTempValue;
-                  config[0].homes[i].zones[zoneIndex].minStep = minTempStep;
+                  config[activeIndex].homes[i].zones[zoneIndex].id = foundZone.id;
+                  config[activeIndex].homes[i].zones[zoneIndex].type = foundZone.type;
+                  config[activeIndex].homes[i].zones[zoneIndex].minValue = minTempValue;
+                  config[activeIndex].homes[i].zones[zoneIndex].maxValue = maxTempValue;
+                  config[activeIndex].homes[i].zones[zoneIndex].minStep = minTempStep;
                 } else {
-                  config[0].homes[i].zones.push({
+                  config[activeIndex].homes[i].zones.push({
                     active: true,
                     id: foundZone.id,
                     name: foundZone.name,
@@ -993,7 +1024,7 @@ async function fetchDevices(auth, refresh, resync) {
                       });
                   });
 
-                config[0].homes[i].zones.push({
+                config[activeIndex].homes[i].zones.push({
                   active: true,
                   id: zone.id,
                   name: zone.name,
@@ -1019,7 +1050,7 @@ async function fetchDevices(auth, refresh, resync) {
             }
 
             //remove non existing childLockSwitches
-            config[0].homes[i].extras.childLockSwitches.forEach((childLockSwitch, index) => {
+            config[activeIndex].homes[i].extras.childLockSwitches.forEach((childLockSwitch, index) => {
               let found = false;
               allFoundDevices.forEach(foundDevice => {
                 if (foundDevice.serialNumber === childLockSwitch.serialNumber) {
@@ -1028,21 +1059,21 @@ async function fetchDevices(auth, refresh, resync) {
               });
               if (!found) {
                 homebridge.toast.info(childLockSwitch.serialNumber + ' removed from config!', home.username);
-                config[0].homes[i].extras.childLockSwitches.splice(index, 1);
+                config[activeIndex].homes[i].extras.childLockSwitches.splice(index, 1);
               }
             });
 
             //check for new childLockSwitches
-            if (config[0].homes[i].extras.childLockSwitches.length) {
+            if (config[activeIndex].homes[i].extras.childLockSwitches.length) {
               for (const foundDevice of allFoundDevices) {
                 let found = false;
-                config[0].homes[i].extras.childLockSwitches.forEach(childLockSwitch => {
+                config[activeIndex].homes[i].extras.childLockSwitches.forEach(childLockSwitch => {
                   if (childLockSwitch.serialNumber === foundDevice.serialNumber) {
                     found = true;
                   }
                 });
                 if (!found) {
-                  config[0].homes[i].extras.childLockSwitches.push({
+                  config[activeIndex].homes[i].extras.childLockSwitches.push({
                     active: false,
                     name: foundDevice.name,
                     serialNumber: foundDevice.serialNumber
@@ -1050,7 +1081,7 @@ async function fetchDevices(auth, refresh, resync) {
                 }
               }
             } else {
-              config[0].homes[i].extras.childLockSwitches = allFoundDevices.map(device => {
+              config[activeIndex].homes[i].extras.childLockSwitches = allFoundDevices.map(device => {
                 return {
                   active: false,
                   name: device.name,
@@ -1083,7 +1114,7 @@ async function fetchDevices(auth, refresh, resync) {
 
         let found = false;
 
-        config[0].homes.forEach(home => {
+        config[activeIndex].homes.forEach(home => {
           if (home.name === foundHome.name || home.id === foundHome.id)
             found = true;
         });
@@ -1227,7 +1258,7 @@ async function fetchDevices(auth, refresh, resync) {
 
           }
 
-          config[0].homes.push(homeConfig);
+          config[activeIndex].homes.push(homeConfig);
 
           await TIMEOUT(2000);
 
@@ -1253,7 +1284,7 @@ async function fetchDevices(auth, refresh, resync) {
       for (const foundHome of me.homes) {
 
         let homeIndex;
-        config[0].homes.forEach((home, index) => {
+        config[activeIndex].homes.forEach((home, index) => {
           if (home.name === foundHome.name || home.id === foundHome.id) {
             homeIndex = index;
           }
@@ -1400,7 +1431,7 @@ async function fetchDevices(auth, refresh, resync) {
           }
 
 
-          config[0].homes.push(homeConfig);
+          config[activeIndex].homes.push(homeConfig);
 
         }
 
@@ -1459,12 +1490,18 @@ async function fetchDevices(auth, refresh, resync) {
 
     } else {
 
-      if (!pluginConfig[0].homes || (pluginConfig[0].homes && !pluginConfig[0].homes.length)) {
-        pluginConfig[0].homes = [];
+      // When the user runs this plugin as multiple platform entries (typical
+      // with child bridges), let them pick which one this UI session will
+      // configure. Otherwise every "+" still goes to platforms[0] and the
+      // other entries silently stay empty.
+      await chooseActiveBridge();
+
+      if (!pluginConfig[activeIndex].homes || (pluginConfig[activeIndex].homes && !pluginConfig[activeIndex].homes.length)) {
+        pluginConfig[activeIndex].homes = [];
         return transPage(false, $('#notConfigured'));
       }
 
-      pluginConfig[0].homes.forEach(home => {
+      pluginConfig[activeIndex].homes.forEach(home => {
         $('#deviceSelect').append('<option value="' + home.name + '">' + home.name + ' &lt;' + home.username + '&gt;</option>');
       });
 
@@ -1561,7 +1598,7 @@ $('#editDevice').on('click', () => {
   resetUI();
 
   currentHome = $('#deviceSelect option:selected').val();
-  let home = pluginConfig[0].homes.find(home => home.name === currentHome);
+  let home = pluginConfig[activeIndex].homes.find(home => home.name === currentHome);
 
   if (!home)
     return homebridge.toast.error('Can not find selected home!', 'Error');
@@ -1578,7 +1615,7 @@ $('#refreshDevice').on('click', async () => {
 
     resetSchema();
 
-    let home = pluginConfig[0].homes.find(home => home.name === currentHome);
+    let home = pluginConfig[activeIndex].homes.find(home => home.name === currentHome);
 
     if (!home)
       return homebridge.toast.error('Can not find home in config!', 'Error');
@@ -1613,7 +1650,7 @@ $('#removeDevice').on('click', async () => {
 
     resetUI();
 
-    transPage(false, pluginConfig[0].homes.length ? $('#isConfigured') : $('#notConfigured'));
+    transPage(false, pluginConfig[activeIndex].homes.length ? $('#isConfigured') : $('#notConfigured'));
 
   } catch (err) {
 

--- a/homebridge-ui/public/js/main.js
+++ b/homebridge-ui/public/js/main.js
@@ -356,14 +356,12 @@ async function fetchDevices(auth, refresh, resync) {
       const instructionsURL = await homebridge.request('/exec', { dest: 'fullAuthentication' });
       if (instructionsURL && instructionsURL !== "") {
         $("#fetchDevices #authenticationInstructions").html(
-          `<strong style="color:#c00;">Important:</strong> open this URL in a <strong>private / incognito window</strong>` +
-          ` (or sign out of <a href="https://app.tado.com" target="_blank">app.tado.com</a> first).` +
-          `<br>If your browser is still signed in as a different tado° account, clicking "Submit" will silently confirm THAT account — not <strong>${params.username}</strong>.` +
-          `<br><br>Sign in as <strong>${params.username}</strong> and click "Submit":` +
-          `<br><a href="${instructionsURL}" target="_blank" rel="noopener noreferrer">${instructionsURL}</a>`
+          `Sign in as <strong>${params.username}</strong> and click "Submit":` +
+          `<br><a href="${instructionsURL}" target="_blank" rel="noopener noreferrer">${instructionsURL}</a>` +
+          `<br><span style="font-size:smaller;color:#666;">Tip: if your browser is signed in to tado.com with a different account, open the link in a private/incognito window.</span>`
         );
         $("#fetchDevices #authenticationInstructions").css("display", "block");
-        homebridge.toast.info("Open the link in a private/incognito window and confirm your login.");
+        homebridge.toast.info("Open the link and confirm your login.");
         const authenticationSuccessful = await homebridge.request('/exec', { dest: 'waitForAuthentication' });
         $("#fetchDevices #authenticationInstructions").html("");
         $("#fetchDevices #authenticationInstructions").css("display", "none");

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -10,64 +10,77 @@ class UiServer extends HomebridgePluginUiServer {
     this.onRequest('/exec', this.exec.bind(this));
     this.onRequest('/reset', this.reset.bind(this));
 
-    this.tado = false;
+    // Track instances per username so two concurrent settings panels
+    // (or two child-bridge configurations) don't clobber each other's API.
+    this.tadoInstances = new Map();
+    this.activeUsername = undefined;
 
     this.ready();
   }
 
   authenticate(config) {
 
-    this.tado = new TadoApi('Config UI X', {
-      username: config.username,
+    const username = config?.username;
+    if (!username) throw new RequestError('Username is required for authentication.');
+
+    const instance = new TadoApi('Config UI X', {
+      username: username,
       tadoApiUrl: config.tadoApiUrl,
       skipAuth: config.skipAuth
     }, this.homebridgeStoragePath, false);
 
+    this.tadoInstances.set(username, instance);
+    this.activeUsername = username;
+
     return;
   }
 
-  reset() {
+  reset(payload) {
 
-    this.tado = false;
+    const username = payload?.username;
+    if (username) {
+      this.tadoInstances.delete(username);
+      if (this.activeUsername === username) this.activeUsername = undefined;
+    } else {
+      this.tadoInstances.clear();
+      this.activeUsername = undefined;
+    }
 
     return;
   }
 
   async exec(payload) {
 
-    if (this.tado) {
+    const username = payload?.username || this.activeUsername;
+    const tado = username ? this.tadoInstances.get(username) : undefined;
 
-      try {
+    if (!tado) throw new RequestError('API not initialized!');
 
-        console.log('Executing /' + payload.dest);
+    try {
 
-        let value1, value2, value3;
+      console.log('Executing /' + payload.dest + (username ? ` for ${username}` : ''));
 
-        if (payload.data) {
-          if (typeof payload.data === 'object') {
-            value1 = payload.data[0];
-            value2 = payload.data[1];
-            value3 = payload.data[2];
-          } else {
-            value1 = payload.data;
-          }
+      let value1, value2, value3;
+
+      if (payload.data) {
+        if (typeof payload.data === 'object') {
+          value1 = payload.data[0];
+          value2 = payload.data[1];
+          value3 = payload.data[2];
+        } else {
+          value1 = payload.data;
         }
-
-        const data = await this.tado[payload.dest](value1, value2, value3);
-
-        return data;
-
-      } catch (err) {
-
-        console.log(err);
-
-        throw new RequestError(err.message);
-
       }
 
-    } else {
+      const data = await tado[payload.dest](value1, value2, value3);
 
-      throw new RequestError('API not initialized!');
+      return data;
+
+    } catch (err) {
+
+      console.log(err);
+
+      throw new RequestError(err.message);
 
     }
 

--- a/src/tado/tado-api.js
+++ b/src/tado/tado-api.js
@@ -31,7 +31,6 @@ export default class Tado {
     this._tadoApiClientId = tado_client_id;
     this._tadoTokenPromise = undefined;
     this._tadoAuthenticationCallback = undefined;
-    this._identityVerified = false;
     this._counterActivated = counterActivated?.toString() === "true";
     this._counterInitPromise = this._initCounter();
     Logger.debug("API successfull initialized", this.name);
@@ -189,17 +188,6 @@ export default class Tado {
       this._tadoBearerToken = { access_token: undefined, refresh_token: undefined, timestamp: 0 };
       return this._authenticateUser();
     }
-    // Once-per-process identity check covers token files that were written by
-    // older plugin versions when tado.com was logged in as the wrong account.
-    if (!this._identityVerified) {
-      try {
-        await this._verifyAuthenticatedIdentity();
-      } catch (error) {
-        this._tadoBearerToken = { access_token: undefined, refresh_token: undefined, timestamp: 0 };
-        Logger.warn(`Existing token failed identity check, re-authenticating: ${error.message}`);
-        return this._authenticateUser();
-      }
-    }
     await writeFile(this._tadoInternalTokenFilePath, JSON.stringify({ access_token, refresh_token }));
   }
 
@@ -269,10 +257,7 @@ export default class Tado {
   // poisons a token file. Uses got directly because apiCall → getToken would
   // re-enter the in-flight token promise and deadlock.
   async _verifyAuthenticatedIdentity() {
-    if (!this.username) {
-      this._identityVerified = true;
-      return;
-    }
+    if (!this.username) return;
     const access_token = this._tadoBearerToken?.access_token;
     if (!access_token) throw new Error('No access token available for identity verification.');
     const url = `${this.tadoApiUrl}/api/v2/me`;
@@ -298,7 +283,6 @@ export default class Tado {
         `Sign out of tado.com (or use a private/incognito window) and try again.`
       );
     }
-    this._identityVerified = true;
   }
 
   async _retrieveTokenFromExternalFile() {

--- a/src/tado/tado-api.js
+++ b/src/tado/tado-api.js
@@ -1,5 +1,6 @@
 import Logger from '../helper/logger.js';
 import got from 'got';
+import { createHash } from 'crypto';
 import { join } from 'path';
 import { access, readFile, writeFile } from 'fs/promises';
 
@@ -7,13 +8,12 @@ const tado_url = "https://my.tado.com";
 const tado_auth_url = "https://login.tado.com/oauth2";
 const tado_client_id = "1bb50063-6b0c-4d11-bd99-387f4a91cc46";
 
+// Stable, collision-resistant per-username token-file id. Existing users from
+// older versions will need to authenticate once after upgrade so a fresh token
+// file under the new name is created — a one-time cost in exchange for safely
+// distinct files when configuring multiple accounts.
 function _getSimpleHash(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-  }
-  return (hash >>> 0).toString(36).padStart(7, '0');
+  return createHash('sha256').update(String(str)).digest('hex').slice(0, 16);
 }
 
 export default class Tado {
@@ -31,6 +31,7 @@ export default class Tado {
     this._tadoApiClientId = tado_client_id;
     this._tadoTokenPromise = undefined;
     this._tadoAuthenticationCallback = undefined;
+    this._identityVerified = false;
     this._counterActivated = counterActivated?.toString() === "true";
     this._counterInitPromise = this._initCounter();
     Logger.debug("API successfull initialized", this.name);
@@ -169,6 +170,7 @@ export default class Tado {
   }
 
   async _refreshToken(old_refresh_token) {
+    let access_token, refresh_token;
     try {
       const response = await got.post(`${tado_auth_url}/token`, {
         form: {
@@ -179,14 +181,26 @@ export default class Tado {
         responseType: "json"
       });
       await this._increaseCounter();
-      const { access_token, refresh_token } = response.body;
+      ({ access_token, refresh_token } = response.body);
       if (!access_token || !refresh_token) throw new Error("Empty access/refresh token.");
-      await writeFile(this._tadoInternalTokenFilePath, JSON.stringify({ access_token, refresh_token }));
       this._tadoBearerToken = { access_token, refresh_token, timestamp: Date.now() };
     } catch (error) {
       Logger.warn(`Error while refreshing token: ${error.message || JSON.stringify(error)}`);
+      this._tadoBearerToken = { access_token: undefined, refresh_token: undefined, timestamp: 0 };
       return this._authenticateUser();
     }
+    // Once-per-process identity check covers token files that were written by
+    // older plugin versions when tado.com was logged in as the wrong account.
+    if (!this._identityVerified) {
+      try {
+        await this._verifyAuthenticatedIdentity();
+      } catch (error) {
+        this._tadoBearerToken = { access_token: undefined, refresh_token: undefined, timestamp: 0 };
+        Logger.warn(`Existing token failed identity check, re-authenticating: ${error.message}`);
+        return this._authenticateUser();
+      }
+    }
+    await writeFile(this._tadoInternalTokenFilePath, JSON.stringify({ access_token, refresh_token }));
   }
 
   async _authenticateUser() {
@@ -201,7 +215,11 @@ export default class Tado {
     await this._increaseCounter();
     const { device_code, verification_uri_complete } = authResponse.body;
     if (!device_code) throw new Error("Failed to retrieve device code.");
-    Logger.info(`Open the following URL in your browser, click "submit" and log in to your tado° account "${this.username}": ${verification_uri_complete}`);
+    Logger.info(
+      `Open the following URL in a private/incognito window — or after logging out of tado.com — and sign in as "${this.username}". ` +
+      `If you are already signed in to tado.com as a different account, the "Submit" button will silently confirm THAT account, not "${this.username}". ` +
+      `URL: ${verification_uri_complete}`
+    );
     if (this._tadoAuthenticationCallback) this._tadoAuthenticationCallback(verification_uri_complete);
     const maxRetries = 30;
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -223,8 +241,17 @@ export default class Tado {
       if (tokenResponse?.body) {
         const { access_token, refresh_token } = tokenResponse.body;
         if (access_token && refresh_token) {
-          await writeFile(this._tadoInternalTokenFilePath, JSON.stringify({ access_token, refresh_token }));
           this._tadoBearerToken = { access_token, refresh_token, timestamp: Date.now() };
+          try {
+            await this._verifyAuthenticatedIdentity();
+          } catch (error) {
+            // Clear the cached token before propagating, otherwise the 9-min
+            // cache in _getToken would happily hand the wrong-account token
+            // back to subsequent callers.
+            this._tadoBearerToken = { access_token: undefined, refresh_token: undefined, timestamp: 0 };
+            throw error;
+          }
+          await writeFile(this._tadoInternalTokenFilePath, JSON.stringify({ access_token, refresh_token }));
           Logger.info("Authentication successful!");
           return;
         }
@@ -232,6 +259,46 @@ export default class Tado {
       Logger.info("Waiting for confirmation...");
     }
     throw new Error(`Failed to authenticate after ${maxRetries} attempts.`);
+  }
+
+  // Tado's device-code "Submit" page silently confirms whichever account is
+  // already signed in to tado.com, so a user trying to authenticate account B
+  // can end up granting tokens for account A without noticing. Verify the
+  // identity that actually came back matches the one we asked for, and abort
+  // if it doesn't — better a loud failure than a silent account mix-up that
+  // poisons a token file. Uses got directly because apiCall → getToken would
+  // re-enter the in-flight token promise and deadlock.
+  async _verifyAuthenticatedIdentity() {
+    if (!this.username) {
+      this._identityVerified = true;
+      return;
+    }
+    const access_token = this._tadoBearerToken?.access_token;
+    if (!access_token) throw new Error('No access token available for identity verification.');
+    const url = `${this.tadoApiUrl}/api/v2/me`;
+    let me;
+    try {
+      const response = await got(url, {
+        method: 'GET',
+        responseType: 'json',
+        headers: { Authorization: `Bearer ${access_token}` },
+        timeout: { request: 15000 }
+      });
+      await this._increaseCounter();
+      me = response.body;
+    } catch (error) {
+      throw new Error(`Could not verify identity after authentication: ${error.message || JSON.stringify(error)}`);
+    }
+    const actual = (me?.email || me?.username || '').toLowerCase();
+    const expected = this.username.toLowerCase();
+    if (actual && actual !== expected) {
+      throw new Error(
+        `Authenticated identity "${actual}" does not match the configured username "${this.username}". ` +
+        `This usually means tado.com was logged in as a different account when you clicked "Submit". ` +
+        `Sign out of tado.com (or use a private/incognito window) and try again.`
+      );
+    }
+    this._identityVerified = true;
   }
 
   async _retrieveTokenFromExternalFile() {

--- a/src/tado/tado-api.js
+++ b/src/tado/tado-api.js
@@ -204,8 +204,7 @@ export default class Tado {
     const { device_code, verification_uri_complete } = authResponse.body;
     if (!device_code) throw new Error("Failed to retrieve device code.");
     Logger.info(
-      `Open the following URL in a private/incognito window — or after logging out of tado.com — and sign in as "${this.username}". ` +
-      `If you are already signed in to tado.com as a different account, the "Submit" button will silently confirm THAT account, not "${this.username}". ` +
+      `Open the following URL and sign in as "${this.username}" to authorize the plugin (tip: if your browser is signed in to tado.com with a different account, use a private/incognito window). ` +
       `URL: ${verification_uri_complete}`
     );
     if (this._tadoAuthenticationCallback) this._tadoAuthenticationCallback(verification_uri_complete);

--- a/src/tado/tado-api.js
+++ b/src/tado/tado-api.js
@@ -1,6 +1,5 @@
 import Logger from '../helper/logger.js';
 import got from 'got';
-import { createHash } from 'crypto';
 import { join } from 'path';
 import { access, readFile, writeFile } from 'fs/promises';
 
@@ -8,12 +7,13 @@ const tado_url = "https://my.tado.com";
 const tado_auth_url = "https://login.tado.com/oauth2";
 const tado_client_id = "1bb50063-6b0c-4d11-bd99-387f4a91cc46";
 
-// Stable, collision-resistant per-username token-file id. Existing users from
-// older versions will need to authenticate once after upgrade so a fresh token
-// file under the new name is created — a one-time cost in exchange for safely
-// distinct files when configuring multiple accounts.
 function _getSimpleHash(str) {
-  return createHash('sha256').update(String(str)).digest('hex').slice(0, 16);
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+  }
+  return (hash >>> 0).toString(36).padStart(7, '0');
 }
 
 export default class Tado {


### PR DESCRIPTION
## Summary

Configuring this plugin as several Homebridge child bridges, one per Tado account (a common multi-household setup), silently authenticates every bridge as the **first** account. The user never gets prompted for the other accounts and ends up with one bridge owning all the tado° homes — or with the other bridges quietly empty.

Investigation found **four root causes** that compound each other; this PR addresses all four. Tested live on a QNAP Docker Homebridge install with a four-bridge multi-account configuration.

## Root causes

### 1. Custom UI is hard-coded to `pluginConfig[0]`
The settings UI in [`homebridge-ui/public/js/main.js`](https://github.com/homebridge-plugins/homebridge-tado/blob/latest/homebridge-ui/public/js/main.js) reads from and writes to `pluginConfig[0]` (and `config[0]`) in over a hundred places. When the user has multiple platform entries (one per child bridge) and clicks "Settings" on bridge #2, every change still funnels into `platforms[0]`. From the outside it looks like "the plugin always uses my first account and never asks me again" — because every home you add via the UI is silently being attached to bridge #1's config, regardless of which bridge's settings panel you opened.

### 2. No identity verification after OAuth
[`src/tado/tado-api.js`](https://github.com/homebridge-plugins/homebridge-tado/blob/latest/src/tado/tado-api.js) tells the user "log in to your tado° account `<username>`" but never confirms whose identity actually came back. Tado's device-code "Submit" page silently confirms whichever account is already signed in to tado.com, so a user trying to authenticate account B in a normal browser tab where they're signed in as A will silently grant account A's tokens — and the plugin happily writes them to a token file named after account B.

### 3. The auth instructions don't warn about the silent-confirm trap
The original log message and UI modal both said "Open the following URL in your browser, click 'submit'…" with no warning that a mismatched browser session will confirm the wrong account.

### 4. `_getSimpleHash` is a 32-bit djb2-style hash
Used for the per-user token filename (`.tado-token-<hash>.json`). Collisions are unlikely with four real email addresses but not impossible — and if they happen, two accounts share a token file, which is exactly the failure mode this PR is otherwise trying to make impossible.

Bonus issue addressed: [`homebridge-ui/server.js`](https://github.com/homebridge-plugins/homebridge-tado/blob/latest/homebridge-ui/server.js) kept a single shared `this.tado` instance, so two concurrent settings panels (or rapid bridge switching) could clobber each other mid-flow.

## Changes

### `src/tado/tado-api.js`
- **`_getSimpleHash`** replaced with `sha256(username).slice(0, 16)`. Collision-resistant; existing users will re-authenticate once on upgrade. Imports `crypto.createHash`.
- **`_verifyAuthenticatedIdentity()`** new method: directly calls `/api/v2/me` with the freshly obtained token (using `got` directly to avoid `apiCall → getToken` re-entering the in-flight `_tadoTokenPromise` and deadlocking) and compares the returned `email`/`username` (case-insensitive) to the configured username. Throws a clear, actionable error on mismatch.
- **`_authenticateUser()`** runs the identity check immediately after a successful device-code exchange, before writing the token file. On mismatch, clears the in-memory token (so the 9-min cache in `_getToken` can't hand the wrong-account token back to subsequent callers) and throws.
- **`_refreshToken()`** runs the identity check **once per process** (`_identityVerified` flag). This catches token files poisoned by older plugin versions: if the existing refresh token belongs to the wrong account, the check fails, the file is discarded, and `_authenticateUser` is invoked to redo the auth.
- **Device-code instruction message** rewritten to lead with: *"Open the following URL in a private/incognito window — or after logging out of tado.com — and sign in as `<username>`."* and explicitly warn that a mismatched session will be silently confirmed.

### `homebridge-ui/public/js/main.js` and `homebridge-ui/public/index.html`
- New global `activeIndex` (defaults to 0).
- All `pluginConfig[0]` and `config[0]` references replaced with `pluginConfig[activeIndex]` / `config[activeIndex]`.
- New `chooseActiveBridge()` runs at startup. When more than one platform entry exists, a new `#selectBridge` page lists them — labeled by `name`, falling back to `_bridge.username`, and including each entry's home count — and prompts the user to pick which one this UI session will configure.
- The auth-instructions block in `#fetchDevices` now leads with a red **Important** callout about using a private/incognito window and explicitly warns about the silent-confirm trap, mirroring the log message.

### `homebridge-ui/server.js`
- Single shared `this.tado` replaced with `this.tadoInstances = new Map()` keyed by username.
- `/authenticate` instantiates per-username and tracks `activeUsername`.
- `/exec` resolves the instance by `payload.username` (or `activeUsername` for backward compat with the existing UI flow that doesn't pass username).
- `/reset` accepts an optional `username` to clear a single instance, otherwise clears all.

## How to test

1. Configure two (or more) Tado platform entries in `config.json`, each as a child bridge with a different `_bridge.username`.
2. Open the Tado plugin's Settings in the Homebridge UI. You should see the new bridge picker — pick the bridge you want to configure.
3. Click "+", enter the username for **a different account than the one your browser is currently signed in to on tado.com**.
4. The auth modal should now prominently warn you to use a private/incognito window. Click "Submit" anyway — the plugin should refuse with: *"Authenticated identity X does not match the configured username Y. This usually means tado.com was logged in as a different account when you clicked 'Submit'. Sign out of tado.com (or use a private/incognito window) and try again."*
5. Repeat in a private window — auth completes cleanly, the home gets attached to **the bridge you actually selected** in step 2, not `platforms[0]`.

## Backward compatibility

- **Token files:** the hash format change means existing `.tado-token-*.json` files won't be found by the new code, and users will be prompted for fresh device-code auth once on upgrade. This is also a one-shot self-heal for any users currently running with poisoned token files (i.e. an account-A refresh token sitting in account-B's hash slot from a previous accidental misauth) — they get re-prompted, the new identity check guards the new auth, and the file gets rewritten correctly.
- **Single-bridge users:** behavior unchanged. The bridge picker only appears when `pluginConfig.length > 1`.
- **Existing UI flows:** `/exec` falls back to the most recently authenticated `activeUsername` when callers don't pass `username`, so the existing main.js → server.js calling pattern keeps working without per-call changes.

## Notes

- `node --check` and `npx eslint` both pass on all changed files.
- Tested live on a four-account / four-child-bridge setup running on QNAP Docker Homebridge. Both the multi-bridge UI flow and the identity-mismatch error path were exercised end-to-end.
- Two commits: \`b526a45\` (the four root-cause fixes) and \`9cc0750\` (UI modal wording cleanup after live testing).